### PR TITLE
use process.env as a layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ config.addLayer(
 console.dir(config.getLayerNames()); // ["layerTwo", "layerOne"]
 
 ```
+
+#### Environment variables
+
+You can also add environment variables from process.env by using a layer name of 'process.env'. In this case, the configuration data passed is an options object. 
+
+These options are
+
+* lowerCase : _true||false_ -> converts environment variable names to lowercase (default true)
+* separator : _char_ -> if this is set, the variable name will be split into a path using the separator (default '_')
+* whitelist : _array_ -> a string array of variables to parse. If this is set, only these variables will be added (default is all variables)
+* match: _regex_ -> whatever variable name matching the regex will be added (default is all variables)
+
+
+```javascript
+// Add a layer containing process.env variables
+config.addLayer( 'process.env' );
+console.log(config.get('home'))
+```
+
 `getLayerNames()` returns the names of the layers inside the configuration ordered from highest to lowest priority.
 
 ### Querying data

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-layered-config 
+# node-layered-config
 [![Build Status](https://travis-ci.org/derWhity/node-layered-config.svg?branch=master)](https://travis-ci.org/derWhity/node-layered-config) [![Dependency Status](https://www.versioneye.com/user/projects/57a679a9fcd74d1602ca57fb/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/57a679a9fcd74d1602ca57fb)
 
 A simple configuration system allowing multiple configuration layers (e.g. defaults, user-defined config)
@@ -28,7 +28,7 @@ If added by using `addlayer()`, every new layer will have a higher priority than
 ```javascript
 // Add a first layer including some data
 config.addLayer(
-    'layerOne', 
+    'layerOne',
     {
         one: 1,
         two: 2,
@@ -41,7 +41,7 @@ config.addLayer(
 // Add another layer
 // This one has a higher priority than "layerOne"
 config.addLayer(
-    'layerTwo', 
+    'layerTwo',
     {
         three: {
             foo: 'overwritten', // This value overwrites the one in layerOne
@@ -54,9 +54,11 @@ console.dir(config.getLayerNames()); // ["layerTwo", "layerOne"]
 
 ```
 
+`getLayerNames()` returns the names of the layers inside the configuration ordered from highest to lowest priority.
+
 #### Environment variables
 
-You can also add environment variables from process.env by using a layer name of 'process.env'. In this case, the configuration data passed is an options object. 
+You can also add environment variables from process.env by using a layer name of 'process.env'. In this case, the configuration data passed is an options object.
 
 These options are
 
@@ -71,9 +73,6 @@ These options are
 config.addLayer( 'process.env' );
 console.log(config.get('home'))
 ```
-
-`getLayerNames()` returns the names of the layers inside the configuration ordered from highest to lowest priority.
-
 ### Querying data
 
 Each value inside the configuration hierarchy can be addressed by using a configuration path that describes the position you want to access. By default, configuration paths use "." as separator. To get the value of "bar" in our example above, the corresponding configuration path would be `three.bar`.
@@ -128,7 +127,7 @@ You can choose to either load each layer one by one using `loadFromFile()` or to
 // Load the contents of userData.hjson into a new layer named "userData"
 config.loadFromFile('./data/userData.hjson')
     .then(/* ... */);
-    
+
 // Load the same file into a layer named "foo"
 config.loadFromFile('./data/userData.hjson', 'foo')
     .then(/* ... */);
@@ -140,10 +139,10 @@ config.removeAllLayers();
 // Files will be loaded in alphabetical order
 config.loadFromDirectory('./data')
     .then(/* ... */);
-    
+
 // Assuming that the directory contains the files "foo.hjson", "bar.json" and "baz.hjson",
 let names = config.getLayerNames(); // ["foo", "baz", "bar"]
-``` 
+```
 
 **Attention:**<br/>
 If both, a `.hjson` and a `.json` file exist having the same filename, the resulting configuration will only contain the data from the `.json` file, because it will be loaded after the `.hjson` one, thus overwriting its data.
@@ -165,10 +164,10 @@ config.addLayer('three', {c: 3}).writeToDisk = true;
 // Write layer "two" to disk
 config.saveToFile('two', 'myConfigFile.hjson')
     .then(/* ... */);
-    
+
 // This will write layers "one" and "three" to the target directory
 config.saveToDirectory('./data')
     .then(/* ... */);
-    
+
 // The "data" directory now contains the files "one.hjson" and "three.hjson"
 ```

--- a/lib/LayeredConfiguration.js
+++ b/lib/LayeredConfiguration.js
@@ -240,6 +240,13 @@ class LayeredConfiguration {
         layerName = this.normalizeLayerName(layerName);
         // Just to be sure: Remove an eventually existing layer
         this.removeLayer(layerName);
+
+
+        // special case: gather process.env keys
+        if (layerName === 'process_env') {
+            configurationData = this.getProcessEnv(configurationData);
+        }
+
         let layer = new Layer(layerName, configurationData);
         this.layers[layerName] = layer;
         this.layerNames.splice(layerIndex, 0, layerName);
@@ -304,6 +311,63 @@ class LayeredConfiguration {
      */
     addLayerAfter(layerName, configurationData, otherLayerName) {
         return this.addLayerRelativeTo(layerName, configurationData, otherLayerName, false);
+    }
+
+    /**
+     * @private
+     * turns process.env variables into json data
+     *
+     * checks all process.env variables against a whitelist, optionally converting to lowercase
+     *
+     * variables are split into a path according to split option (default is '_') so WHOGLOO_TEST=baz becomes {whogloo: { test: 'baz' }}
+     *
+     * variables matching the whitelist are returned as a json object
+     *
+     * @param {Object} options    The options used to parse process.env
+     * @return {configurationData} The configurationData object that has been parsed from process.env
+     *
+     */
+
+    getProcessEnv(options) {
+        let data = {};
+        let env = process.env;
+
+        options = options || {};
+
+        options.separator = options.separator || '_';
+        options.lowerCase = options.lowerCase || true;
+        options.whitelist = options.whitelist || [];
+
+        if (options.lowerCase) {
+            env = {};
+
+            Object.keys(process.env).forEach((key) => {
+                env[key.toLowerCase()] = process.env[key];
+            });
+        }
+
+        Object.keys(env).filter((key) => {
+            if (options.match) {
+
+                if (options.whitelist.length) {
+                    return key.match(options.match) || options.whitelist.indexOf(key) !== -1;
+                } else {
+                    return key.match(options.match);
+                }
+            } else {
+                return !options.whitelist.length || options.whitelist.indexOf(key) !== -1;
+            }
+        }).sort().forEach((key) => {
+            if (options.separator) {
+
+                console.log("---->",key.split(options.separator).join('.'),env[key])
+                _.setWith(data,key.split(options.separator).join('.'),env[key],Object);
+            } else {
+                _.set(data,key, env[key]);
+            }
+        });
+
+        return data;
     }
 
     /**


### PR DESCRIPTION
this PR allows the developer to use process.env variables as a config layer. Variables in the whitelist or matching a pattern can be made available as part of the configuration tree.

For example,

```
FOO_BAR=true
FOO_BAZ=SomeData
```

``` javascript
// Add a layer containing process.env variables
config.addLayer( 'process.env' , { match: /^foo/});
console.log("#1",config.get('foo'));
console.log("#2",config.get('foo.baz'));
```

will show

```
#1 { 
   "foo":  {
     "bar": true,
     "baz": "SomeData"
  }
}

#2 "SomeData"
```
